### PR TITLE
Fix git blame regex for boundary commits that include leading '^'

### DIFF
--- a/git-tools.js
+++ b/git-tools.js
@@ -217,7 +217,7 @@ Repo.prototype.blame = function( options, callback ) {
 
 	args.push( "--", options.path );
 
-	var rBlame = /^(\w+)(\s(\S+))?\s+(\d+)\)\s(.*)$/;
+	var rBlame = /^\^*(\w+)(\s(\S+))?\s+(\d+)\)\s(.*)$/;
 
 	args.push(function( error, blame ) {
 		if ( error ) {


### PR DESCRIPTION
Ex:

``` bash
$ git blame -s .gitignore
```

Yields:

```
^c3a3b95 1) .DS_Store
^c3a3b95 2) npm-debug.log
```

In this case commit c3a3b95 is the initial commit in my repository. Since this commit has no parent in the scope of the blame command, it is marked as a boundary commit with the leading '^'.

When running git blame on a file with boundary commits present on a blame line, you get an error:

`Uncaught TypeError: Cannot read property '1' of null`

Which occurs on line 232 of git-tools.js:

``` javascript
var lines = blame.split( /\r?\n/ );
  lines = lines.map(function( line ) {
  var matches = rBlame.exec( line );

  return {
    commit: matches[ 1 ],  // matches is null here
    path: matches[ 3 ] || options.path,
    lineNumber: parseInt( matches[ 4 ], 10 ),
    content: matches[ 5 ]
  };
});
```

Let me know if you'd like me to add tests, but doing so may require a larger refactor of the blame method.
