### PR TITLE
Fixed issue with command line options for exec() from the config() method.

### DIFF
--- a/git-tools.js
+++ b/git-tools.js
@@ -266,7 +266,7 @@ Repo.prototype.branches = function( callback ) {
 };
 
 Repo.prototype.config = function( name, callback ) {
-	this.exec( "config --get " + name, function( error, stdout ) {
+	this.exec( "config", "--get", name, function( error, stdout ) {
 		if ( error ) {
 			if ( /^Command failed:\s+$/.test( error.message ) ) {
 				return callback( null, null );


### PR DESCRIPTION
Hello,

I noticed that `config()` didn't work on my systems (OS X).

* The problem was that `exec()` got "config --get" and the key as one argument string instead of as a vector of arguments.
* Other Repo-methods use vectors of arguments and work properly.

This small change makes `config()` conform to the pattern of the surrounding methods, calling `exec()` with a vector of arguments ("config", "--get" and the key) instead of a single string, "config --get key".