### PR TITLE
Fixed issue when no tags exist

### DIFF
--- a/git-tools.js
+++ b/git-tools.js
@@ -360,6 +360,10 @@ Repo.prototype.tags = function( callback ) {
 			return callback( error );
 		}
 
+		if ( !data ) {
+			return callback( null, [] );
+		}
+
 		var tags = data.split( "\n\n" ).map(function( tag ) {
 			var lines = tag.split( "\n" );
 			var name = lines[ 0 ];


### PR DESCRIPTION
When calling `repo.tags(...)` from inside a repository that does not have any tags, the callback is called with an array of one element that looks something like: `{ name: '', sha: undefined, date: Invalid Date }`.

This is due to `data.split( "\n\n" )` always containing one element, regardless of the length of the string.