### PR TITLE
prevent regex mismatch from causing uncaught exception

### DIFF
--- a/git-tools.js
+++ b/git-tools.js
@@ -20,9 +20,10 @@ Repo.parsePerson = (function() {
 	var rPerson = /^(\S+)\s(.+)$/;
 	return function( person ) {
 		var matches = rPerson.exec( person );
+		
 		return {
-			email: matches[ 1 ],
-			name: matches[ 2 ]
+			email: matches ? matches[ 1 ] : '',
+			name: matches ? matches[ 2 ] : ''
 		};
 	};
 })();


### PR DESCRIPTION
 resolves secondary error in https://github.com/scottgonzalez/node-git-tools/issues/9